### PR TITLE
Pos neg switch fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Package: msPurity
 Type: Package
 Title: Automated Evaluation of Precursor Ion Purity for Mass Spectrometry Based
     Fragmentation in Metabolomics
-Version: 1.5.4
-Date: 2018-04-05
+Version: 1.6.1
+Date: 2018-06-09
 Author: Thomas N. Lawson, Ralf Weber, Martin Jones, Mark Viant, Warwick Dunn
 Maintainer: Thomas N. Lawson <thomas.nigel.lawson@gmail.com>
 Description: Assess the contribution of the targeted precursor in fragmentation

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+CHANGES IN VERSION 1.6.1
+=========================
+* Bug fix. For pos/neg switching acquisition two files are can be generated when converting from RAW to mzML (1 for pos, 1 for neg).   The resulting files retention time scans were not being tracked properly in msPurity in these cases. This is now fixed. Thanks
+  to Julien (https://github.com/jsaintvanne) for spotting the bug.
+
+
 CHANGES IN VERSION 1.5.1
 =========================
 * Updates for database creation (can use CAMERA objects now)

--- a/R/purityA-constructor.R
+++ b/R/purityA-constructor.R
@@ -195,7 +195,7 @@ assessPuritySingle <- function(filepth,
   }
 
   # Get a shortened mzR dataframe
-  mrdfshrt <- mrdf[mrdf$msLevel==2,][,c("seqNum","precursorIntensity",
+  mrdfshrt <- mrdf[mrdf$msLevel==2,][,c("seqNum","acquisitionNum","precursorIntensity",
                                         "precursorMZ", "precursorRT",
                                         "precursorScanNum", "id", "filename")]
 
@@ -590,14 +590,11 @@ getmrdf <- function(files, backend='pwiz'){
       mrdfn  <- missing_prec_scan(mrdfn)
     }
 
-    # mrdfn  <- missing_prec_scan(mrdfn)
-    if(length(files)==1){
-
-    }
     #mrdfn$fileid <- rep(i,nrow(mrdfn))
-    mrdfn$filename <- rep(basename(files[1]),nrow(mrdfn))
+    mrdfn$filename <- rep(basename(files[i]),nrow(mrdfn))
     mrdfn$precursorRT <- NA
-    mrdfn[mrdfn$msLevel==2,]$precursorRT <- mrdfn[mrdfn$precursorScanNum,]$retentionTime
+    # precursorScanNum matches to the acuisitionNum, get row matching row number and relevant retntion time
+    mrdfn[mrdfn$msLevel==2,]$precursorRT <- mrdfn[match(mrdfn[mrdfn$msLevel==2,]$precursorScanNum, mrdfn$acquisitionNum),]$retentionTime
 
     if(!is.data.frame(mrdf)){
       mrdf <- mrdfn
@@ -614,7 +611,7 @@ missing_prec_scan <- function(mrdfn){
       # Find most recent ms1 level scan
       for (x in i:1){
         if(mrdfn[x,]$msLevel==1){
-          mrdfn[i,]$precursorScanNum = mrdfn[x,]$seqNum
+          mrdfn[i,]$precursorScanNum = mrdfn[x,]$acquisitionNum
           break
         }
       }

--- a/R/purityA-frag4feature.R
+++ b/R/purityA-frag4feature.R
@@ -185,6 +185,7 @@ mzmatching <- function(mtchRow, mz1=mz1, ppm=ppm, pro=pro){
 
   if(ppmerror<ppm){
     mtchRow$precurMtchID <- pro$seqNum
+    mtchRow$precurMtchScan <- pro$precursorScanNum
     mtchRow$precurMtchRT <- pro$precursorRT
     mtchRow$precurMtchMZ <- mz1
     mtchRow$precurMtchPPM <- ppmerror

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,55 +1,30 @@
-#----------------------------------------------------------------
-# AppVeyor configuration for R packages
-#
-# REFERENCES:
-# * AppVeyor CI: https://ci.appveyor.com/
-# * r-travis: https://github.com/craigcitro/r-travis
-#
-# Validate your .appveyor.yml file at
-# https://ci.appveyor.com/tools/validate-yaml
-#----------------------------------------------------------------
-environment:
-  _R_CHECK_FORCE_SUGGESTS_: false
-
-  matrix:
-
-  - R_VERSION: release
-    R_ARCH: x64
-    BIOC_USE_DEVEL: false
-
-
 # DO NOT CHANGE the "init" and "install" sections below
 
 # Download script file from GitHub
 init:
   ps: |
         $ErrorActionPreference = "Stop"
-        Invoke-WebRequest http://raw.github.com/HenrikBengtsson/r-appveyor/master/scripts/appveyor-tool.ps1 -OutFile "..\appveyor-tool.ps1"
+        Invoke-WebRequest http://raw.github.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1 -OutFile "..\appveyor-tool.ps1"
         Import-Module '..\appveyor-tool.ps1'
 install:
-  - ps: Bootstrap
+  ps: Bootstrap
 
-
-
+cache:
+  #- C:\RLibrary -> DESCRIPTION
 
 # Adapt as necessary starting from here
-
 build_script:
- - travis-tool.sh install_github hadley/devtools
- - travis-tool.sh install_bioc_deps
- - echo source("https://bioconductor.org/biocLite.R");biocLite("msPurityData"); > dinstall.R
- - Rscript dinstall.R
- - R CMD INSTALL .
-
-
+  - R -e source('https://install-github.me/r-lib/remotes')
+  - travis-tool.sh install_bioc_deps
+  - travis-tool.sh install_deps
+  - echo source("https://bioconductor.org/biocLite.R");biocLite("msPurityData"); > dinstall.R
 
 test_script:
   - travis-tool.sh run_tests
 
-after_test:
-  - 7z a all-Rout.zip *.Rcheck\**\*.Rout *.Rcheck\**\*.fail
-
-
+on_failure:
+  - 7z a failure.zip *.Rcheck\*
+  - appveyor PushArtifact failure.zip
 
 artifacts:
   - path: '*.Rcheck\**\*.log'
@@ -58,8 +33,11 @@ artifacts:
   - path: '*.Rcheck\**\*.out'
     name: Logs
 
-  - path: all-Rout.zip
-    name: AllRout
+  - path: '*.Rcheck\**\*.fail'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.Rout'
+    name: Logs
 
   - path: '\*_*.tar.gz'
     name: Bits
@@ -67,6 +45,13 @@ artifacts:
   - path: '\*_*.zip'
     name: Bits
 
-on_failure:
-  - 7z a failure.zip *.Rcheck\*
-  - appveyor PushArtifact failure.zip
+# don't check suggested packges
+environment:
+    global:
+      WARNINGS_ARE_ERRORS: true
+      _R_CHECK_FORCE_SUGGESTS_: false
+      R_COMPILE_AND_INSTALL_PACKAGES: always
+      R_ARCH: x64
+      USE_RTOOLS: true
+    matrix:
+      - R_VERSION: release

--- a/tests/testthat/test.sm.R
+++ b/tests/testthat/test.sm.R
@@ -34,7 +34,7 @@ test_that("checking spectral matching functions (massbank)", {
                          LEFT JOIN library_meta ON matches.lid=library_meta.lid
                          WHERE matches.score IS NOT NULL')
 
-  expect_equal(ncol(XLI), 78)
+  expect_equal(ncol(XLI), 79)
   expect_equal(nrow(XLI), 45)
   expect_equal(round(sum(XLI$mz),3), 7626.806)
   expect_equal(round(sum(XLI$precursorMZ),3), 7627.127)


### PR DESCRIPTION
Bug fix.

For pos/neg switching acquisition two files are can be generated when converting from RAW to mzML (1 for pos, 1 for neg).   The resulting files retention time scans were not being tracked properly in msPurity in some of these cases. This is now fixed. 

Thanks  to Julien (https://github.com/jsaintvanne) for spotting the bug.