### PR TITLE
Handle duplicate grpid in metadata for createMSP

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Package: msPurity
 Type: Package
 Title: Automated Evaluation of Precursor Ion Purity for Mass Spectrometry Based
     Fragmentation in Metabolomics
-Version: 1.9.10
-Date: 2019-04-25
+Version: 1.9.11
+Date: 2019-04-26
 Author: Thomas N. Lawson, Ralf Weber, Martin Jones, Mark Viant, Warwick Dunn
 Maintainer: Thomas N. Lawson <thomas.nigel.lawson@gmail.com>
 Description: msPurity R package and associated Galaxy tools were developed to: 

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+CHANGES IN VERSION 1.9.11
+=========================
+* Bug fix for createMSP - now handles metada with duplicate grpids
+
+
 CHANGES IN VERSION 1.9.10
 =========================
 * Documentation updates

--- a/NEWS
+++ b/NEWS
@@ -2,7 +2,6 @@ CHANGES IN VERSION 1.9.11
 =========================
 * Bug fix for createMSP - now handles metada with duplicate grpids
 
-
 CHANGES IN VERSION 1.9.10
 =========================
 * Documentation updates
@@ -15,7 +14,6 @@ CHANGES IN VERSION 1.9.9
     + Updated version spectral_matching that allows for more flexibility
 * Vigenettes and documentation update
 
-
 CHANGES IN VERSION 1.9.8
 =========================
 * NEW FUNCTION: filterFragSpectra (for purityA objects)
@@ -26,14 +24,10 @@ CHANGES IN VERSION 1.9.8
     + Create msp files from purityA objects where XCMS features have been linked to fragmentation spectra
 * Updated create_database and spectral matching to have the option to use averaged fragmentation spectra
 
-
-
-
 CHANGES IN VERSION 1.9.2
 =========================
 * Bug fix for groupPeaks and groupPeaksEx (the ppm argument was not working and there was inconsistent behaviour with larger datasets). Thanks to Elliot for spotting (https://github.com/litepalmer)
 * Updated documentation for spectral matching
-
 
 CHANGES IN VERSION 1.7.6
 =========================
@@ -46,12 +40,10 @@ CHANGES IN VERSION 1.6.1
 * Bug fix. For pos/neg switching acquisition two files are can be generated when converting from RAW to mzML (1 for pos, 1 for neg).   The resulting files retention time scans were not being tracked properly in msPurity in these cases. This is now fixed. Thanks
   to Julien (https://github.com/jsaintvanne) for spotting the bug.
 
-
 CHANGES IN VERSION 1.5.1
 =========================
 * Updates for database creation (can use CAMERA objects now)
 * averageSpectra parameter 'MSFileReader' deprecated MSFileReader. Should use csvFile instead, MSFileReader option will still work but a warning will be given
-
 
 CHANGES IN VERSION 1.4.1/2/3
 =========================
@@ -60,7 +52,6 @@ CHANGES IN VERSION 1.4.1/2/3
 * Separation of sqlite database creation. Now can be called on it's own or with frag4feature
   (allows the Galaxy tool to be simplified)
 
-
 CHANGES IN VERSION 1.3.9
 =========================
 * Added very basic SIMS stitch compatibility
@@ -68,17 +59,14 @@ CHANGES IN VERSION 1.3.9
 * Update of purityX to handle obiwarp RT correction (requires recording the RT RAW at an earlier step)
 * bug fix for when library spectra is bigger than target spectra (thanks Martin)
 
-
 CHANGES IN VERSION 1.3.1
 =========================
 * Add spectral matching functionality for LC-MS/MS
-
 
 CHANGES IN VERSION 1.1.1
 =========================
 * Added pcalc functions to be used by user
 * Added option to remove isotopes from calculation
-
 
 CHANGES IN VERSION 0.99.10/11/12
 =========================
@@ -91,16 +79,13 @@ CHANGES IN VERSION 0.99.9
 * Updated handling of RT corrected xcmsSet objects for frag4feature function
 * Additional column added for tracking ms/ms spectra
 
-
 CHANGES IN VERSION 0.99.8
 =========================
 * User option to change the mzR backend library
 
-
 CHANGES IN VERSION 0.99.4/5/6/7
 =========================
 * Troubleshooting mac build failure
-
 
 CHANGES IN VERSION 0.99.3
 =========================
@@ -108,14 +93,12 @@ CHANGES IN VERSION 0.99.3
 ** Peaklists can now be averaged across each class using the function groupPeaks() for the class purityD
 ** A list of dataframes can also be grouped togther using the function groupPeakEx()
 
-
 CHANGES IN VERSION 0.99.2
 =========================
 * Updated class names purityPD to purityD
 * Updated class names purityLC to purityX
 * Updated vignette to reflect slightly different terminology
 * Added normalised TIC option for purityD
-
 
 msPurity v0.99.0 (Release date: 2016-04-08)
 =========================

--- a/inst/extdata/tests/msp/av_all_dupmeta.msp
+++ b/inst/extdata/tests/msp/av_all_dupmeta.msp
@@ -1,0 +1,22 @@
+RECORD_TITLE: Sulfamethizole | [M+H]+ |  MZ:116.0706 | RT:47.8 | grpid:12 | file:NA
+MS$FOCUSED_ION: PRECURSOR_M/Z 116.070557825043
+AC$CHROMATOGRAPHY: RETENTION_TIME 47.814411
+MS$FOCUSED_ION: PRECURSOR_TYPE [M+H]+
+AC$MASS_SPECTROMETRY: ION_MODE POSITIVE
+XCMS groupid (grpid): 12
+COMMENT: Exported from msPurity purityA object using function createMSP, using method 'av_all' msPurity version:1.9.10 
+PK$NUM_PEAK: 1
+PK$PEAK: m/z int. rel.int.
+116.070899963379	2295773.625	100
+
+RECORD_TITLE: possible other compound | [M+H]+ |  MZ:116.0706 | RT:47.8 | grpid:12 | file:NA
+MS$FOCUSED_ION: PRECURSOR_M/Z 116.070557825043
+AC$CHROMATOGRAPHY: RETENTION_TIME 47.814411
+MS$FOCUSED_ION: PRECURSOR_TYPE [M+H]+
+AC$MASS_SPECTROMETRY: ION_MODE POSITIVE
+XCMS groupid (grpid): 12
+COMMENT: Exported from msPurity purityA object using function createMSP, using method 'av_all' msPurity version:1.9.10 
+PK$NUM_PEAK: 1
+PK$PEAK: m/z int. rel.int.
+116.070899963379	2295773.625	100
+

--- a/tests/testthat/test.2_purityA.R
+++ b/tests/testthat/test.2_purityA.R
@@ -324,6 +324,21 @@ test_that("checking createMSP based functions", {
   expect_equal(av_all_msp_new, av_all_msp_old)
 
 
+  ################################
+  # When two metadata details for single XCMS feature
+  ################################
+  metadatad <- metadata
+  metadatad[3, ] <- metadatad[1,]
+  metadatad[3,4] <- 'possible other compound'
+
+  av_all_msp_new_dupmeta_pth <- file.path(tmp_dir,'av_all_dupmeta.msp')
+  createMSP(pa, msp_file = av_all_msp_new_dupmeta_pth, metadata = metadatad, method = "av_all", xcms_groupids = c(8, 12))
+
+  av_all_msp_dupmeta_new <- get_msp_str(av_all_msp_new_dupmeta_pth)
+  av_all_msp_dupmeta_old <- get_msp_str(system.file("extdata", "tests","msp", "av_all_dupmeta.msp", package="msPurity"))
+  expect_equal(av_all_msp_dupmeta_new, av_all_msp_dupmeta_old)
+
+
   #createMSP(pa, msp_file = 'all.msp', metadata = metadata, method = "all", xcms_groupids = c(8, 12))
   #createMSP(pa, msp_file = 'max.msp', metadata = metadata, method = "max", xcms_groupids = c(8, 12))
   #createMSP(pa, msp_file = 'av_inter.msp', metadata = metadata, method = "av_inter", xcms_groupids = c(8, 12))


### PR DESCRIPTION
In some cases the metadata associated for an XCMS feature could be ambiguous  (i.e. the source could be potentially 2 or more standards). 

In these cases the metadata should have multiple rows indicating separate meta details e.g.

| grpid             | adduct             | RECORD_TITLE |
| -------------- | ---------------- | ---------------- |
| 12  | [M+H]+           | Sulfamethizole |
| 12  | [M+H]+           | Other compound with same mz and rt      |

In this case multiple MSP spectra will be made for XCMS group 12 -  one for each row