### PR TITLE
Troubleshoot mac biocon failure

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Version: 1.9.12
 Date: 2019-04-28
 Author: Thomas N. Lawson, Ralf Weber, Martin Jones, Mark Viant, Warwick Dunn
 Maintainer: Thomas N. Lawson <thomas.nigel.lawson@gmail.com>
-Description: msPurity R package and associated Galaxy tools were developed to: 
+Description: msPurity R package was developed to: 
      1) Assess the spectral quality of fragmentation spectra by evaluating the "precursor ion purity". 
      2) Process fragmentation spectra. 
      3) Perform spectral matching.
@@ -22,6 +22,7 @@ Description: msPurity R package and associated Galaxy tools were developed to:
 Encoding: UTF-8
 License: GPL (>= 2)
 LazyData: TRUE
+BugReports: https://github.com/computational-metabolomics/msPurity/issues/new
 Depends:
     Rcpp
 Imports:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Package: msPurity
 Type: Package
 Title: Automated Evaluation of Precursor Ion Purity for Mass Spectrometry Based
     Fragmentation in Metabolomics
-Version: 1.9.11
-Date: 2019-04-26
+Version: 1.9.12
+Date: 2019-04-28
 Author: Thomas N. Lawson, Ralf Weber, Martin Jones, Mark Viant, Warwick Dunn
 Maintainer: Thomas N. Lawson <thomas.nigel.lawson@gmail.com>
 Description: msPurity R package and associated Galaxy tools were developed to: 

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+CHANGES IN VERSION 1.9.12
+=========================
+* Troublshoot mac "[MSData::Spectrum::getMZIntensityPairs()] Sizes do not match" error
+
 CHANGES IN VERSION 1.9.11
 =========================
 * Bug fix for createMSP - now handles metada with duplicate grpids

--- a/vignettes/msPurity-vignette.Rmd
+++ b/vignettes/msPurity-vignette.Rmd
@@ -276,17 +276,21 @@ The slot `predictions` provides the anticipated (predicted) purity scores for ea
 _XCMS run on an LC-MS dataset_
 ```{r results='hide', message=FALSE, warning=FALSE,  echo = TRUE}
 msPths <- list.files(system.file("extdata", "lcms", "mzML", package="msPurityData"), full.names = TRUE, pattern = "LCMS_")
-xset <- xcms::xcmsSet(msPths)
-xset <- xcms::group(xset)
-xset <- xcms::retcor(xset)
-xset <- xcms::group(xset)
+
+#Run xcms
+#xset <- xcmsSet(msPths)
+#xset <- group(xset)
+
+# Or load an XCMS xcmsSet object saved earlier
+xset <- readRDS(system.file("extdata", "tests", "xcms", "ms_only_xset.rds", package="msPurity"))
+# Make sure the file paths are correct
+xset@filepaths[1] <- msPths[basename(msPths)=="LCMS_1.mzML"]
+xset@filepaths[2] <- msPths[basename(msPths)=="LCMS_2.mzML"]
 ```
 
 _Perform purity calculations_
 ```{r}
-ppLCMS <- purityX(xset, offsets=c(0.5, 0.5), xgroups = c(1, 2))
-
-print(ppLCMS@predictions[1:3,])
+px <- purityX(xset, cores = 1, xgroups = c(1, 2), ilim=0)
 ```
 
 


### PR DESCRIPTION
Bioconductor vignette is failing on this error  "[MSData::Spectrum::getMZIntensityPairs()] Sizes do not match" when using purityX

The error does not occur locally on my mac and the unit-tests for purityX do not fail. I think it is a Rcpp error that might be hard to diagnose so I have updated the vignette code to match the unit-test code and hope that it might fix it.