### PR TITLE
Fix for purityX example (failing build in bioconductor)

### DIFF
--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -52,9 +52,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { os: ubuntu-latest, r: 'devel', bioc: '3.19', cont: "bioconductor/bioconductor_docker:devel", rspm: "https://packagemanager.rstudio.com/cran/__linux__/jammy/latest" }
-          # - { os: macOS-latest, r: 'devel', bioc: '3.19'}
-          - { os: windows-latest, r: 'devel', bioc: '3.19'}
+          - { os: ubuntu-latest, r: 'release', bioc: '3.19'}
+          # - { os: macOS-latest, r: 'devel', bioc: '3.20'}
+          - { os: windows-latest, r: 'release', bioc: '3.19'}
           ## Check https://github.com/r-lib/actions/tree/master/examples
           ## for examples using the http-user-agent
     env:

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -135,7 +135,14 @@ jobs:
           ## https://github.com/r-lib/usethis/commit/f1f1e0d10c1ebc75fd4c18fa7e2de4551fd9978f#diff-9bfee71065492f63457918efcd912cf2
           brew install imagemagick@6
 
+          ## For textshaping, required by ragg, and required by pkgdown
+          brew install harfbuzz fribidi
 
+          ## For installing usethis's dependency gert
+          brew install libgit2
+
+          ## Required for tcltk
+          brew install xquartz --cask
 
           ## required for ncdf4
           ## brew install netcdf ## Does not work as it is compiled with gcc

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -136,7 +136,11 @@ jobs:
           brew install imagemagick@6
 
           ## For textshaping, required by ragg, and required by pkgdown
-          brew install harfbuzz fribidi
+          brew install harfbuzz
+          brew install fribidi
+
+          ## For installing usethis's dependency gert
+          brew install libgit2
 
           ## required for ncdf4
           ## brew install netcdf ## Does not work as it is compiled with gcc

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -52,9 +52,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { os: ubuntu-latest, r: 'latest', bioc: '3.2', cont: "bioconductor/bioconductor_docker:latest", rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest" }
-          - { os: macOS-latest, r: 'latest', bioc: '3.2'}
-          - { os: windows-latest, r: 'latest', bioc: '3.2'}
+          - { os: ubuntu-latest, r: 'latest', bioc: '3.19', cont: "bioconductor/bioconductor_docker:latest", rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest" }
+          - { os: macOS-latest, r: 'latest', bioc: '3.19'}
+          - { os: windows-latest, r: 'latest', bioc: '3.19'}
           ## Check https://github.com/r-lib/actions/tree/master/examples
           ## for examples using the http-user-agent
     env:

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -53,7 +53,7 @@ jobs:
       matrix:
         config:
           - { os: ubuntu-latest, r: 'devel', bioc: '3.19', cont: "bioconductor/bioconductor_docker:devel", rspm: "https://packagemanager.rstudio.com/cran/__linux__/jammy/latest" }
-          - { os: macOS-latest, r: 'devel', bioc: '3.19'}
+          # - { os: macOS-latest, r: 'devel', bioc: '3.19'}
           - { os: windows-latest, r: 'devel', bioc: '3.19'}
           ## Check https://github.com/r-lib/actions/tree/master/examples
           ## for examples using the http-user-agent

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -135,12 +135,7 @@ jobs:
           ## https://github.com/r-lib/usethis/commit/f1f1e0d10c1ebc75fd4c18fa7e2de4551fd9978f#diff-9bfee71065492f63457918efcd912cf2
           brew install imagemagick@6
 
-          ## For textshaping, required by ragg, and required by pkgdown
-          brew install harfbuzz
-          brew install fribidi
 
-          ## For installing usethis's dependency gert
-          brew install libgit2
 
           ## required for ncdf4
           ## brew install netcdf ## Does not work as it is compiled with gcc

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -138,9 +138,6 @@ jobs:
           ## For textshaping, required by ragg, and required by pkgdown
           brew install harfbuzz fribidi
 
-          ## For installing usethis's dependency gert
-          brew install libgit2
-
           ## required for ncdf4
           ## brew install netcdf ## Does not work as it is compiled with gcc
           ## Use pre-compiled libraries from https://mac.r-project.org/libs-4/

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -195,9 +195,20 @@ jobs:
               BiocManager::repositories()
               ) else BiocManager::repositories()
 
-          # install suggested packages
-          BiocManager::install(c("MSnbase", "xcms", "BiocStyle", "msPurityData", "CAMERA"))
+          # Workaround for problems with cached S4objects in binary packages
+          BiocManager::install("GenomeInfoDb", force = TRUE, type = "source")
+          BiocManager::install("BiocParallel", force = TRUE, type = "source")
+          BiocManager::install("S4Vectors", force = TRUE, type = "source")
+          BiocManager::install("SummarizedExperiment", force = TRUE, type = "source")
+          ## install xcms with dependencies - to ensure dependencies are installed from source;
+          ## somehow install_local installs binary packages instead.
+          BiocManager::install("mzR", force = TRUE)
+          BiocManager::install("MSnbase", force = TRUE, type = "source")
+          BiocManager::install("xcms", force = TRUE, type = "source", dependencies = TRUE)
+
+          BiocManager::install(c("BiocStyle", "msPurityData", "CAMERA"))
           install.packages(c("rmarkdown", "RPostgres", "RMySQL"))
+
 
           ## For running the checks
           message(paste('****', Sys.time(), 'installing rcmdcheck and BiocCheck ****'))

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -52,9 +52,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { os: ubuntu-latest, r: 'latest', bioc: '3.17', cont: "bioconductor/bioconductor_docker:latest", rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest" }
-          - { os: macOS-latest, r: 'latest', bioc: '3.17'}
-          - { os: windows-latest, r: 'latest', bioc: '3.17'}
+          - { os: ubuntu-latest, r: 'latest', bioc: '3.2', cont: "bioconductor/bioconductor_docker:latest", rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest" }
+          - { os: macOS-latest, r: 'latest', bioc: '3.2'}
+          - { os: windows-latest, r: 'latest', bioc: '3.2'}
           ## Check https://github.com/r-lib/actions/tree/master/examples
           ## for examples using the http-user-agent
     env:

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -52,9 +52,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { os: ubuntu-latest, r: 'release', bioc: '3.19'}
-          # - { os: macOS-latest, r: 'devel', bioc: '3.20'}
-          - { os: windows-latest, r: 'release', bioc: '3.19'}
+          - { os: ubuntu-latest, r: 'devel', bioc: 'devel', cont: "bioconductor/bioconductor_docker:devel", rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest" }
+          #- { os: macOS-latest, r: 'next', bioc: '3.19'}
+          - { os: windows-latest, r: 'next', bioc: '3.19'}
           ## Check https://github.com/r-lib/actions/tree/master/examples
           ## for examples using the http-user-agent
     env:
@@ -191,7 +191,7 @@ jobs:
           gha_repos <- if(
               .Platform$OS.type == "unix" && Sys.info()["sysname"] != "Darwin"
           ) c(
-              "AnVIL" = "https://bioconductordocker.blob.core.windows.net/packages/3.17/bioc",
+              "AnVIL" = "https://bioconductordocker.blob.core.windows.net/packages/3.19/bioc",
               BiocManager::repositories()
               ) else BiocManager::repositories()
 
@@ -205,8 +205,9 @@ jobs:
           BiocManager::install("mzR", force = TRUE)
           BiocManager::install("MSnbase", force = TRUE, type = "source")
           BiocManager::install("xcms", force = TRUE, type = "source", dependencies = TRUE)
-
-          BiocManager::install(c("BiocStyle", "msPurityData", "CAMERA"))
+          BiocManager::install("msPurityData", force = TRUE, type = "source", dependencies = TRUE)
+          BiocManager::install("CAMERA", force = TRUE, type = "source", dependencies = TRUE)
+          BiocManager::install(c("BiocStyle"))
           install.packages(c("rmarkdown", "RPostgres", "RMySQL"))
 
 

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -52,9 +52,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { os: ubuntu-latest, r: 'latest', bioc: '3.19', cont: "bioconductor/bioconductor_docker:latest", rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest" }
-          - { os: macOS-latest, r: 'latest', bioc: '3.19'}
-          - { os: windows-latest, r: 'latest', bioc: '3.19'}
+          - { os: ubuntu-latest, r: 'devel', bioc: '3.19', cont: "bioconductor/bioconductor_docker:devel", rspm: "https://packagemanager.rstudio.com/cran/__linux__/jammy/latest" }
+          - { os: macOS-latest, r: 'devel', bioc: '3.19'}
+          - { os: windows-latest, r: 'devel', bioc: '3.19'}
           ## Check https://github.com/r-lib/actions/tree/master/examples
           ## for examples using the http-user-agent
     env:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Package: msPurity
 Type: Package
 Title: Automated Evaluation of Precursor Ion Purity for Mass Spectrometry Based
     Fragmentation in Metabolomics
-Version: 1.27.1
-Date: 2023-08-30
+Version: 1.31.1
+Date: 2024-05-09
 Authors@R: c(
     person(given = "Thomas N.", family = "Lawson",
         email = "thomas.nigel.lawson@gmail.com", role = c("aut", "cre"),
@@ -61,7 +61,7 @@ Suggests:
     RPostgres,
     RMySQL
 VignetteBuilder: knitr
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 Roxygen: list(markdown = TRUE)
 biocViews: MassSpectrometry, Metabolomics, Software
 Collate: 

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+CHANGES IN VERSION 1.30.1 / 1.31.1
++ Update example for purityX causing build error
+
 CHANGES IN VERSION 1.27.1
 + createMSP fix - now uses the median precursor MZ and precursor RT in the MSP file
 

--- a/R/purityX-constructor.R
+++ b/R/purityX-constructor.R
@@ -54,14 +54,12 @@
 #'
 #' @return a purityX object containing a dataframe of predicted purity scores
 #' @examples
-#' msPths <- list.files(system.file("extdata", "lcms", "mzML",
-#'                     package="msPurityData"), full.names = TRUE,
-#'                     pattern = "LCMS_")
-#' xset <- xcms::xcmsSet(msPths)
-#' xset <- xcms::group(xset)
-#' xset <- xcms::retcor(xset)
-#' xset <- xcms::group(xset)
-#' ppLCMS <- purityX(xset, cores = 1, xgroups = c(1, 2))
+#'
+#' msPths <- list.files(system.file("extdata", "lcms", "mzML", package="msPurityData"), full.names = TRUE, pattern = "LCMS_")
+#' xset <- readRDS(system.file("extdata", "tests", "xcms", "ms_only_xset_OLD.rds", package="msPurity"))
+#' xset@filepaths[1] <- msPths[basename(msPths)=="LCMS_1.mzML"]
+#' xset@filepaths[2] <- msPths[basename(msPths)=="LCMS_2.mzML"]
+#' px <- purityX(xset, singleFile = 1)
 #'
 #' @export
 purityX <- function(xset, purityType="purityFWHMmedian", offsets=c(0.5, 0.5),

--- a/man/msPurity.Rd
+++ b/man/msPurity.Rd
@@ -2,8 +2,31 @@
 % Please edit documentation in R/msPurity.R
 \docType{package}
 \name{msPurity}
+\alias{msPurity-package}
 \alias{msPurity}
 \title{\code{msPurity} package}
 \description{
 \href{https://bioconductor.org/packages/release/bioc/html/msPurity.html}{msPurity Bioconductor}
+}
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://github.com/computational-metabolomics/msPurity/}
+  \item Report bugs at \url{https://github.com/computational-metabolomics/msPurity/issues/new}
+}
+
+}
+\author{
+\strong{Maintainer}: Thomas N. Lawson \email{thomas.nigel.lawson@gmail.com} (\href{https://orcid.org/0000-0002-5915-7980}{ORCID})
+
+Other contributors:
+\itemize{
+  \item Ralf Weber [contributor]
+  \item Martin Jones [contributor]
+  \item Julien Saint-Vanne [contributor]
+  \item Andris Jankevics [contributor]
+  \item Mark Viant [thesis advisor]
+  \item Warwick Dunn [thesis advisor]
+}
+
 }

--- a/man/purityX.Rd
+++ b/man/purityX.Rd
@@ -69,13 +69,11 @@ Constructor for the purityX class.
 Given an XCMS object get the anticipated precursor purity of the grouped peaks
 }
 \examples{
-msPths <- list.files(system.file("extdata", "lcms", "mzML",
-                    package="msPurityData"), full.names = TRUE,
-                    pattern = "LCMS_")
-xset <- xcms::xcmsSet(msPths)
-xset <- xcms::group(xset)
-xset <- xcms::retcor(xset)
-xset <- xcms::group(xset)
-ppLCMS <- purityX(xset, cores = 1, xgroups = c(1, 2))
+
+msPths <- list.files(system.file("extdata", "lcms", "mzML", package="msPurityData"), full.names = TRUE, pattern = "LCMS_")
+xset <- readRDS(system.file("extdata", "tests", "xcms", "ms_only_xset_OLD.rds", package="msPurity"))
+xset@filepaths[1] <- msPths[basename(msPths)=="LCMS_1.mzML"]
+xset@filepaths[2] <- msPths[basename(msPths)=="LCMS_2.mzML"]
+px <- purityX(xset, singleFile = 1)
 
 }


### PR DESCRIPTION
In the example for purityX constructor function an error is occuring on the Bioconductor build.

This is due to an error within the old XCMS class when used in parallel. To avoid this error within msPurity I have simply taken a pre-saved XCMS object.

