### PR TITLE
v1.37.3 - update for tests only - library database path for library vs library spectral matching test updated

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: msPurity
 Type: Package
 Title: Automated Evaluation of Precursor Ion Purity for Mass Spectrometry Based
     Fragmentation in Metabolomics
-Version: 1.37.2
+Version: 1.37.3
 Date: 2025-02-19
 Authors@R: c(
     person(given = "Thomas N.", family = "Lawson",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Title: Automated Evaluation of Precursor Ion Purity for Mass Spectrometry Based
     Fragmentation in Metabolomics
 Version: 1.37.3
-Date: 2025-02-19
+Date: 2025-03-10
 Authors@R: c(
     person(given = "Thomas N.", family = "Lawson",
         email = "thomas.nigel.lawson@gmail.com", role = c("aut", "cre"),

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,5 @@
 CHANGES IN VERSION 1.37.3
-+ Update library database path for lvl spectral matching testing (required after local SQLite database removed from msPurityData) 
++ Update within the tests only (not within the R code base): library database path for lvl spectral matching testing (required after removal of the local SQLite database from msPurityData).
 
 CHANGES IN VERSION 1.37.2
 + Bug fix for subsetting the grouped data frame in the `average_xcms_grouped_msms_indiv` function

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+CHANGES IN VERSION 1.37.3
++ Update library database path for lvl spectral matching testing (required after local SQLite database removed from msPurityData) 
+
 CHANGES IN VERSION 1.37.2
 + Bug fix for subsetting the grouped data frame in the `average_xcms_grouped_msms_indiv` function
 

--- a/tests/testthat/test.5_sm.R
+++ b/tests/testthat/test.5_sm.R
@@ -73,11 +73,11 @@ test_that("checking spectral matching functions (spectralMatching) library vs li
   rid <- paste0(paste0(sample(LETTERS, 5, TRUE), collapse=""),  paste0(sample(9999, 1, TRUE), collapse=""), ".sqlite")
   sm_out_pth <- file.path(td, rid)
 
+  l_dbPth <- file.path(td, "library_spectra.db")
+  download.file("https://zenodo.org/records/18700802/files/library_spectra.db?download=1", 
+                l_dbPth, mode = "wb", quiet = TRUE)
 
-  q_dbPth <- system.file("extdata", "library_spectra", "library_spectra.db", package="msPurityData")
-  l_dbPth <- system.file("extdata", "library_spectra", "library_spectra.db", package="msPurityData")
-
-  result <- spectralMatching(q_dbPth=q_dbPth,
+  result <- spectralMatching(q_dbPth=l_dbPth,
                              l_dbPth=l_dbPth,
                              q_pids = c(1,2,3),
                              q_spectraTypes = NA,


### PR DESCRIPTION
Update library database path for llibrary vs library spectral matching testing (required after local SQLite spectral library database removed from msPurityData and now available from zenodo) 